### PR TITLE
fix: /setup・/join・/settings が Vercel でビルドされない問題を修正

### DIFF
--- a/frontend/app/join/page.tsx
+++ b/frontend/app/join/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+export const dynamic = "force-dynamic"
+
 import { useRouter, useSearchParams } from "next/navigation"
 import { Suspense } from "react"
 import { useLiff } from "@/hooks/use-liff"

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+export const dynamic = "force-dynamic"
+
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { useLiff } from "@/hooks/use-liff"

--- a/frontend/app/setup/page.tsx
+++ b/frontend/app/setup/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+export const dynamic = "force-dynamic"
+
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { useLiff } from "@/hooks/use-liff"
@@ -34,6 +36,17 @@ export default function SetupPage() {
   const router = useRouter()
   const { isLoading, isInClient, error } = useLiff()
   const [calendarOpen, setCalendarOpen] = useState(false)
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<SetupFormValues>({
+    resolver: zodResolver(setupSchema),
+  })
+
+  const selectedDate = watch("dogBirthday")
 
   if (isLoading) {
     return (
@@ -55,18 +68,6 @@ export default function SetupPage() {
       </div>
     )
   }
-
-  const {
-    register,
-    handleSubmit,
-    setValue,
-    watch,
-    formState: { errors, isSubmitting },
-  } = useForm<SetupFormValues>({
-    resolver: zodResolver(setupSchema),
-  })
-
-  const selectedDate = watch("dogBirthday")
 
   const onSubmit = async (_data: SetupFormValues) => {
     // モック段階：APIは呼ばずそのままリダイレクト


### PR DESCRIPTION
## 概要
Vercel のビルドで `/setup`・`/join`・`/settings` が Route 一覧に出ず 404 になっていた問題を修正。

## 原因
- `setup/page.tsx` で `useForm` が early return の後に呼ばれていた（Rules of Hooks 違反）
- Vercel（Linux / 1 worker）環境では Next.js 16 + Turbopack がこの違反をビルド時に検出してページを除外していた可能性がある

## 対応
- `setup/page.tsx`：`useForm` / `watch` を early return より前に移動
- 3ページに `export const dynamic = 'force-dynamic'` を追加

## 動作確認
- [ ] Vercel デプロイ後に `/setup`・`/join`・`/settings` が 404 にならないことを確認