### PR TITLE
feat: 状態確認Flex Message実装 #22

### DIFF
--- a/backend/app/controllers/webhooks/line_controller.rb
+++ b/backend/app/controllers/webhooks/line_controller.rb
@@ -72,6 +72,23 @@ module Webhooks
         return
       end
 
+      if data["action"] == "status_check"
+        dog_id = data["dog_id"]
+        if dog_id.present?
+          dog = user.dogs.find_by(id: dog_id)
+          return unless dog
+          reply_status_flex_message(event["replyToken"], dog)
+        else
+          dogs = user.dogs
+          if dogs.count == 1
+            reply_status_flex_message(event["replyToken"], dogs.first)
+          else
+            reply_status_dog_select_quick_reply(event["replyToken"], dogs)
+          end
+        end
+        return
+      end
+
       care_type = data["care_type"]
       return unless CareRecord::CARE_TYPES.include?(care_type)
 
@@ -140,6 +157,97 @@ module Webhooks
         type: "action",
         action: { type: "postback", label: label, data: data, displayText: label }
       }
+    end
+
+    def reply_status_dog_select_quick_reply(reply_token, dogs)
+      items = dogs.map do |dog|
+        quick_reply_postback(dog.name, "action=status_check&dog_id=#{dog.id}")
+      end
+      client.reply_message(reply_token, {
+        type: "text",
+        text: "どの子の状態を確認しますか？",
+        quickReply: { items: items }
+      })
+    end
+
+    def reply_status_flex_message(reply_token, dog)
+      status = dog.latest_care_status
+      alert_settings = dog.alert_settings.index_by(&:care_type)
+      client.reply_message(reply_token, build_status_flex_message(dog, status, alert_settings))
+    end
+
+    def build_status_flex_message(dog, status, alert_settings)
+      {
+        type: "flex",
+        altText: "#{dog.name} の状態",
+        contents: {
+          type: "bubble",
+          header: {
+            type: "box",
+            layout: "vertical",
+            backgroundColor: "#F5F0E8",
+            contents: [
+              { type: "text", text: "#{dog.name} の状態", weight: "bold", size: "lg", color: "#4A3728" }
+            ]
+          },
+          body: {
+            type: "box",
+            layout: "vertical",
+            spacing: "md",
+            contents: [
+              status_row("💧", "おしっこ", elapsed_text(status[:pee]),  alert_exceeded?(status[:pee],  alert_settings["pee"])),
+              status_row("💩", "うんち",   elapsed_text(status[:poop]), alert_exceeded?(status[:poop], alert_settings["poop"])),
+              status_row("🦴", "散歩",     "今日#{status[:walk_today_count]}回", false),
+              status_row("🍚", "ごはん",   meal_text(status[:meal]), false)
+            ]
+          },
+          footer: {
+            type: "box",
+            layout: "vertical",
+            contents: [
+              {
+                type: "button",
+                style: "link",
+                action: {
+                  type: "uri",
+                  label: "記録を修正する",
+                  uri: "#{ENV.fetch('LIFF_BASE_URL')}/timeline"
+                }
+              }
+            ]
+          }
+        }
+      }
+    end
+
+    def status_row(emoji, label, value_text, alert)
+      {
+        type: "box",
+        layout: "horizontal",
+        contents: [
+          { type: "text", text: "#{emoji} #{label}", flex: 2, size: "sm", color: "#555555" },
+          { type: "text", text: "#{value_text}#{alert ? ' ⚠️' : ''}", flex: 3, size: "sm", align: "end", color: alert ? "#CC0000" : "#333333", wrap: true }
+        ]
+      }
+    end
+
+    def elapsed_text(record)
+      return "記録なし" unless record
+
+      minutes = ((Time.current - record.recorded_at) / 60).to_i
+      minutes < 60 ? "#{minutes}分前" : "#{minutes / 60}時間前"
+    end
+
+    def meal_text(record)
+      return "記録なし" unless record
+      record.recorded_at.strftime("%H:%M")
+    end
+
+    def alert_exceeded?(record, alert_setting)
+      return false unless record && alert_setting
+
+      elapsed_hours = (Time.current - record.recorded_at) / 3600.0
+      elapsed_hours > alert_setting.interval_hours
     end
 
     def fetch_profile(line_user_id)

--- a/backend/app/models/dog.rb
+++ b/backend/app/models/dog.rb
@@ -4,4 +4,16 @@ class Dog < ApplicationRecord
   has_many :alert_settings, dependent: :destroy
 
   validates :name, presence: true
+
+  def latest_care_status
+    {
+      pee:  care_records.where(care_type: "pee").order(recorded_at: :desc).first,
+      poop: care_records.where(care_type: "poop").order(recorded_at: :desc).first,
+      meal: care_records.where(care_type: "meal").order(recorded_at: :desc).first,
+      walk_today_count: care_records
+        .where(care_type: %w[walk_short walk_long])
+        .where(recorded_at: Time.current.beginning_of_day..)
+        .count
+    }
+  end
 end

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -51,7 +51,7 @@ Phase 4：計測・判断
 ### Step 3：バックエンド
 - [x] Webhook基盤 → #20
 - [x] ケア記録（ボタン→DB）→ #21
-- [ ] 状態確認Flex Message → #22
+- [x] 状態確認Flex Message → #22
 - [ ] 排泄アラート → #8
 
 ### Step 4：フロント→API接続

--- a/docs/scrap/2026-05-26_status-flex-message.md
+++ b/docs/scrap/2026-05-26_status-flex-message.md
@@ -58,10 +58,23 @@ issue #22のモック通り。「最後の食事が何時か」は経過時間�
 
 ## 言語化チェックリスト
 
-- [ ] なぜFlex Messageの組み立てをコントローラのprivateメソッドに置いたのか（サービスオブジェクトにしなかった理由）
-- [ ] `Dog#latest_care_status` をモデルに置いた理由は？Active Recordとしての判断軸は？
-- [ ] `alert_settings.index_by(&:care_type)` で何をしているか（なぜHashにするのか）
-- [ ] `walk_today_count` のクエリ（`beginning_of_day..` の書き方）
-- [ ] `⚠️` の判定：アラート設定がない犬への対応はどうなっているか
-- [ ] 多頭飼いの状態確認フロー：`action=status_check` → Quick Reply → `action=status_check&dog_id=X` の流れ
-- [ ] `elapsed_text` と `meal_text` を分けた意図
+- [x] なぜFlex Messageの組み立てをコントローラのprivateメソッドに置いたのか（サービスオブジェクトにしなかった理由）
+  - MVPの段階では動くものを優先。サービスオブジェクトにするメリット（複数箇所から呼ばれる・テスト分離・ロジックの複雑化）が出たタイミングで切り分ける。今は1箇所からしか呼ばれていないのでprivateメソッドで十分。
+
+- [x] `Dog#latest_care_status` をモデルに置いた理由は？Active Recordとしての判断軸は？
+  - DBのデータを処理してwebhook経由でLINEに送る処理なので、DBの知識はモデルに閉じ込める。`Dog` に `has_many :care_records` / `has_many :alert_settings` のリレーションが書いてあるからこそ、モデルだけで完結できる。DDDだとRepositoryが担う部分だが、Active Recordはモデルがリレーションもアクセスも全部知っているという設計。
+
+- [x] `alert_settings.index_by(&:care_type)` で何をしているか（なぜHashにするのか）
+  - 配列をHashに変換して、care_typeをキーに一発で取れるようにしている。Flex Messageで4回参照するので、毎回 `find` で検索するより `alert_settings["pee"]` とキー指定する方が効率的かつ読みやすい。
+
+- [x] `walk_today_count` のクエリ（`beginning_of_day..` の書き方）
+  - `0..1` のように終端を作らず `0..` とすると「0を含む上限なし」の範囲になる。`beginning_of_day..` で「今日の0時以降のレコードをすべて取る」という意味。SQLでは `WHERE recorded_at >= '今日の00:00:00'` に変換される。
+
+- [x] `⚠️` の判定：アラート設定がない犬への対応はどうなっているか
+  - 犬のアラート設定レコード自体がなければ `alert_settings["pee"]` は `nil` になる。`alert_exceeded?` の先頭で `return false unless record && alert_setting` としているので、`nil` が渡されると即 `false` を返す → ⚠️は出ない。DBのデフォルト値（`interval_hours: 4`）はあくまでレコード新規作成時のデフォルトで、レコードがない場合には使われない。
+
+- [x] 多頭飼いの状態確認フロー：`action=status_check` → Quick Reply → `action=status_check&dog_id=X` の流れ
+  - 最初の `action=status_check` では犬が特定できないので、Quick Replyに `action=status_check&dog_id=X` を仕込んで返す。ユーザーが犬を選ぶと2回目のpostbackが来て犬が確定する。`dog_id` と `action` を両方持って返ってくる2段階の仕組み。
+
+- [x] `elapsed_text` と `meal_text` を分けた意図
+  - おしっこ・うんちは「どれくらい経ったか」が重要（次のお世話タイミング・⚠️判定に繋がる）→ 経過時間表示。ごはんは「何時に食べたか」の方が直感的（その日によって変わるし緊急度が低い）→ HH:MM表示。ユーザーが何を知りたいかで表示形式を変えた。

--- a/docs/scrap/2026-05-26_status-flex-message.md
+++ b/docs/scrap/2026-05-26_status-flex-message.md
@@ -1,0 +1,67 @@
+# 状態確認Flex Message 実装ログ #22
+
+## 実装したもの
+
+「状態確認」ボタンタップ時に、DBから最新のケア記録を取得してFlex Messageで返信する機能。
+
+```
+┌─────────────────────────┐
+│ まる の状態              │
+├─────────────────────────┤
+│ 💧 おしっこ   2時間前   │
+│ 💩 うんち     5時間前 ⚠️│
+│ 🦴 散歩       今日2回   │
+│ 🍚 ごはん     12:00     │
+├─────────────────────────┤
+│      [記録を修正する]    │
+└─────────────────────────┘
+```
+
+---
+
+## 設計判断
+
+### postbackのルーティング
+
+`action=status_check` というpostback dataを追加。既存の `walk_select` と同じパターン。
+
+```
+action=status_check          → 犬1頭ならそのまま表示、複数ならQuick Reply
+action=status_check&dog_id=1 → 指定の犬のステータスを表示
+```
+
+### ロジックをモデルとコントローラに分けた理由
+
+- **`Dog#latest_care_status`**（モデル）：DBから何を取ってくるかはデータの問題 → Active Recordのモデル層
+- **Flex Messageの組み立て**（コントローラのprivateメソッド）：LINEという外部サービスへの表示フォーマット → プレゼンテーション層
+
+サービスオブジェクトに切り出さなかった理由：#21のケア記録と同じコントローラのスタイルを踏襲。Flex Messageビルダーだけで新しいクラスを作るほどの複雑さがなかった。
+
+### ⚠️ 判定ロジック
+
+```ruby
+elapsed_hours = (Time.current - record.recorded_at) / 3600.0
+elapsed_hours > alert_setting.interval_hours
+```
+
+`alert_settings` テーブルの `interval_hours` と比較。アラート設定がない犬は⚠️表示なし。
+
+### ごはんだけHH:MM表示にした理由
+
+issue #22のモック通り。「最後の食事が何時か」は経過時間より絶対時刻の方が直感的。
+
+### 散歩は「今日X回」
+
+`walk_short` + `walk_long` を合算して当日分だけカウント。コースの種類より「何回出たか」が重要な情報のため。
+
+---
+
+## 言語化チェックリスト
+
+- [ ] なぜFlex Messageの組み立てをコントローラのprivateメソッドに置いたのか（サービスオブジェクトにしなかった理由）
+- [ ] `Dog#latest_care_status` をモデルに置いた理由は？Active Recordとしての判断軸は？
+- [ ] `alert_settings.index_by(&:care_type)` で何をしているか（なぜHashにするのか）
+- [ ] `walk_today_count` のクエリ（`beginning_of_day..` の書き方）
+- [ ] `⚠️` の判定：アラート設定がない犬への対応はどうなっているか
+- [ ] 多頭飼いの状態確認フロー：`action=status_check` → Quick Reply → `action=status_check&dog_id=X` の流れ
+- [ ] `elapsed_text` と `meal_text` を分けた意図


### PR DESCRIPTION
## 概要
「状態確認」ボタンタップ時に、DBから最新のケア記録を取得してFlex Messageで返信する機能を実装した。

Closes #22

## 設計の判断
- DBクエリ（`Dog#latest_care_status`）はモデルに置いた。「DBの知識はモデルに閉じ込める」というRailsの基本方針に沿った判断。
- Flex Messageの組み立て（`build_status_flex_message`）はコントローラのprivateメソッドに置いた。LINEという外部サービスへの表示フォーマットはプレゼンテーション層の責務のため。
- 多頭飼い時のQuick Replyは#21のケア記録と同じ設計（`action=status_check&dog_id=X`でpostbackを2段階にする）。
- ⚠️表示は`alert_settings.interval_hours`との比較で判定。アラート設定がない犬は⚠️なし。
- ごはんのみHH:MM表示、他は経過時間（XX分前/XX時間前）で表示。

## 動作確認
- [ ] 状態確認ボタンでFlex Messageが返信される
- [ ] おしっこ/うんち/散歩/ごはんの最新状態が表示される
- [ ] 排泄がアラート設定時間を超えたら ⚠️ が表示される
- [ ] [記録を修正する] からLIFFタイムラインを開ける
- [ ] 多頭飼い時にQuick Replyで犬を選択できる

## 補足・残課題
- LIFFのURLは`LIFF_BASE_URL/timeline`を使用。LIFF側の本実装は#30（フロント→API接続）で行う。
- 動作確認はデプロイ後に実施予定。