### PR TITLE
fix: 犬未登録時にセットアップ画面へリダイレクト

### DIFF
--- a/frontend/app/timeline/page.tsx
+++ b/frontend/app/timeline/page.tsx
@@ -103,7 +103,7 @@ export default function ShibaCareTimeline() {
         const { token, dogs } = await api.auth.line(accessToken)
         setAuthToken(token)
         if (dogs.length === 0) {
-          setFetchError("犬が登録されていません")
+          router.replace("/setup")
           return
         }
         const dog = dogs[0]


### PR DESCRIPTION
## 概要
犬が未登録の状態でLIFFを開いたとき、タイムラインページで「犬が登録されていません」と表示されて止まっていた。APIレスポンスで `dogs` が空であることが判明した時点でフロントが `/setup` にリダイレクトするよう修正した。

## 設計の判断
「犬が0件」という情報はすでにAPIレスポンスで取得済みのため、バックエンドのルーティングは不要。何を表示するかはフロントの責務と判断し、`timeline/page.tsx` 内で処理した。

`router.push` ではなく `router.replace` を使った理由は、`push` だとブラウザ履歴に `/timeline` が残り、「戻る」操作で再び `/timeline` → `/setup` の無限ループが発生するため。

## 動作確認
- マージ後にLIFFからセットアップリンクを開いて確認予定

## 補足・残課題
- なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)