### PR TITLE
fix: 設定画面遷移をフルリロードに変更しLIFFトークン取得を確実にする

### DIFF
--- a/frontend/app/timeline/page.tsx
+++ b/frontend/app/timeline/page.tsx
@@ -171,7 +171,7 @@ export default function ShibaCareTimeline() {
   }
 
   const handleSettings = () => {
-    router.push("/settings")
+    window.location.href = "/settings"
   }
 
   const handleAddEntry = () => {


### PR DESCRIPTION
## 概要
タイムラインから設定画面へのSPA遷移（`router.push`）では、`useLiff` フックがコンポーネントのマウントのたびに `liff.init()` を呼び直し、`liff.getAccessToken()` が null を返してしまう。その結果、APIコールが発生せず保存ボタンが無効のままになっていた。`window.location.href` によるフルリロードに変更し、LIFFが毎回正しく初期化されるようにした。

## 設計の判断
本来の解決策はReact ContextでLIFF初期化状態をアプリ全体で共有し、`liff.init()` を1回だけ呼ぶ設計にすることだが、設定画面は頻繁に開く画面ではないため、MVPではフルリロードで対応する判断をした。

## 動作確認
- マージ後にタイムラインの設定ボタンを押して保存できることを確認予定

## 補足・残課題
- フルリロードにより設定画面を開くたびに「読み込み中...」が表示されるが、使用頻度が低いため許容範囲と判断
- 本質的な解決はReact ContextによるLIFF状態の共有（将来の改善候補）

🤖 Generated with [Claude Code](https://claude.com/claude-code)