### PR TITLE
fix: LINE SDK V1のPostbackイベントで.digを使わないよう修正

### DIFF
--- a/backend/app/controllers/webhooks/line_controller.rb
+++ b/backend/app/controllers/webhooks/line_controller.rb
@@ -62,7 +62,7 @@ module Webhooks
 
     def handle_postback(event)
       line_user_id = event["source"]["userId"]
-      data = Rack::Utils.parse_query(event.dig("postback", "data"))
+      data = Rack::Utils.parse_query(event["postback"]["data"])
 
       user = User.find_by(line_user_id: line_user_id)
       return unless user


### PR DESCRIPTION
## 概要
リッチメニューのpostbackボタンを押したときに `NoMethodError (undefined method 'dig')` が発生していた。LINE SDK V1の `Postback` イベントオブジェクトは `dig` をサポートしていないため、`event["postback"]["data"]` に修正。

## エラー
```
NoMethodError (undefined method 'dig' for an instance of Line::Bot::Event::Postback)
  app/controllers/webhooks/line_controller.rb:65
```

## 修正
```diff
- data = Rack::Utils.parse_query(event.dig("postback", "data"))
+ data = Rack::Utils.parse_query(event["postback"]["data"])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)