### PR TITLE
fix: LIFF login後に元のURLへ戻るよう redirectUri を指定

### DIFF
--- a/docs/scrap/2026-05-31_liff-login-redirect-uri-bug.md
+++ b/docs/scrap/2026-05-31_liff-login-redirect-uri-bug.md
@@ -1,0 +1,37 @@
+# LIFF login() に redirectUri がなかったバグ
+
+## 何が起きていたか
+
+招待リンク（`/join?token=xxx`）を初回アクセス（LIFFアプリ未認証）で開いたとき、
+`/setup`（新規犬の登録画面）に遷移してしまっていた。
+
+## 原因
+
+`use-liff.ts` の `liff.login()` に `redirectUri` を指定していなかった。
+
+LIFF の認証フロー：
+1. ユーザーが `/join?token=xxx` を開く
+2. `liff.init()` 完了後、`liff.isLoggedIn()` が false（初回）
+3. `liff.login()` を呼ぶ → LINE 認証画面へ遷移
+4. 認証後、LIFF がリダイレクト先を決める
+5. `redirectUri` の指定がないため、LIFF Developer Console に設定されたエンドポイント URL（`/`）に戻る
+6. `/` → `/timeline` → `dogs: []` → `/setup` に遷移
+
+## 修正
+
+```typescript
+// before
+liff.login()
+
+// after
+liff.login({ redirectUri: window.location.href })
+```
+
+`window.location.href` を渡すことで、認証後に元の URL（`/join?token=xxx` など）に戻るようになる。
+
+## 言語化チェックリスト
+
+- [ ] `liff.isLoggedIn()` が false になるのはどんな状況？
+- [ ] `liff.isInClient()` と `liff.isLoggedIn()` の違いは？
+- [ ] `redirectUri` を指定しなかった場合、LIFF はどこに戻るか？
+- [ ] この修正が効くのはどの状況に限られるか（外部ブラウザでは効かない理由は？）

--- a/frontend/hooks/use-liff.ts
+++ b/frontend/hooks/use-liff.ts
@@ -39,7 +39,7 @@ export function useLiff(): UseLiffResult {
         setIsInClient(inClient)
         if (!inClient) return // 外部ブラウザはフォールバック表示のみ
         if (!liff.isLoggedIn()) {
-          liff.login()
+          liff.login({ redirectUri: window.location.href })
           return
         }
         setAccessToken(liff.getAccessToken())


### PR DESCRIPTION
## 変更内容

`liff.login()` に `redirectUri: window.location.href` を追加。

## 背景

招待リンク（`/join?token=xxx`）を初回アクセスで開いた際、LIFF 認証後にルート（`/`）へ戻ってしまい、そのまま `/timeline` → `/setup` に遷移してしまっていた。

## レビューチェックリスト

- [ ] 招待リンクを未認証状態で開いたとき、認証後に `/join?token=xxx` に戻るか
- [ ] 認証済みユーザーが招待リンクを開いたとき、通常通り参加画面が表示されるか
- [ ] タイムラインなど他のページで `liff.login()` が呼ばれる状況でも問題ないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)