### PR TITLE
feat: タイムラインを過去24時間表示に変更・編集後に再ソート

### DIFF
--- a/backend/app/controllers/api/v1/care_records_controller.rb
+++ b/backend/app/controllers/api/v1/care_records_controller.rb
@@ -11,7 +11,7 @@ module Api
 
         records = dog.care_records
           .includes(:user)
-          .where(recorded_at: Time.current.beginning_of_day..)
+          .where(recorded_at: 24.hours.ago..)
           .order(recorded_at: :desc)
 
         render json: records.map { |r|

--- a/docs/scrap/2026-05-31_timeline-24h-resort.md
+++ b/docs/scrap/2026-05-31_timeline-24h-resort.md
@@ -1,0 +1,41 @@
+# タイムラインを過去24時間表示に変更・編集後に再ソート
+
+## 何を変えたか
+
+### 1. 表示範囲を「今日0時以降」→「過去24時間」に変更
+
+**バックエンド** (`care_records_controller.rb`):
+
+```ruby
+# before
+.where(recorded_at: Time.current.beginning_of_day..)
+
+# after
+.where(recorded_at: 24.hours.ago..)
+```
+
+### 2. 編集後に recorded_at で再ソート
+
+**フロントエンド** (`timeline/page.tsx`):
+
+```typescript
+setRecords((prev) =>
+  prev
+    .map((r) => (r.id === editTarget.id ? toTimelineEntry(updated) : r))
+    .sort((a, b) => new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime())
+)
+```
+
+### 3. セクションタイトルを「最近の{犬の名前}」に変更
+
+## なぜ beginning_of_day ではダメだったか
+
+`beginning_of_day` は「今日の0時」を起点にする。
+深夜2時に記録した場合、翌朝4時には「昨日の記録」になって消えてしまう。
+`24.hours.ago` にすることで0時をまたいでも直近24時間分が常に表示される。
+
+## 言語化チェックリスト
+
+- [ ] `Time.current.beginning_of_day` と `24.hours.ago` の違いを具体例で説明できるか
+- [ ] 編集後に再ソートが必要な理由は？（API側でソートされていても何故フロントでも必要か）
+- [ ] `sort((a, b) => new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime())` が降順になる理由は？

--- a/frontend/app/timeline/page.tsx
+++ b/frontend/app/timeline/page.tsx
@@ -163,7 +163,11 @@ export default function ShibaCareTimeline() {
         care_type: editTarget.care_type,
         recorded_at: new Date(editTarget.recorded_at).toISOString(),
       })
-      setRecords((prev) => prev.map((r) => (r.id === editTarget.id ? toTimelineEntry(updated) : r)))
+      setRecords((prev) =>
+        prev
+          .map((r) => (r.id === editTarget.id ? toTimelineEntry(updated) : r))
+          .sort((a, b) => new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime())
+      )
       setEditTarget(null)
     } finally {
       setIsUpdating(false)
@@ -285,7 +289,7 @@ export default function ShibaCareTimeline() {
               <PencilLine className="h-3.5 w-3.5 text-primary" />
             </div>
             <h2 className="text-sm font-bold text-primary tracking-wide">
-              今日の記録
+              最近の{dogName}
             </h2>
           </div>
 


### PR DESCRIPTION
Closes #81

## 変更内容

- バックエンド：`beginning_of_day` → `24.hours.ago` に変更し、0時をまたいだ記録も表示
- フロントエンド：編集後に `recorded_at` 降順で再ソート
- セクションタイトルを「最近の{犬の名前}」に変更

## レビューチェックリスト

- [ ] 過去24時間の記録が表示される
- [ ] 時間を編集したあと、タイムラインの並び順が更新される
- [ ] セクションタイトルに犬の名前が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)