### PR TITLE
feat: /health エンドポイントを追加

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "/health", to: proc { [200, {}, ["ok"]] }
+
   post "/webhooks/line", to: "webhooks/line#receive"
 
   namespace :api do


### PR DESCRIPTION
## 変更内容

cron-job.org から定期 ping してRenderのスピンダウンを防ぐため、`/health` エンドポイントを追加。

コントローラー不要で `routes.rb` に proc を1行書くだけで対応。

```
GET /health → 200 ok
```

## レビューチェックリスト

- [ ] `GET /health` が 200 を返すか（デプロイ後に cron-job.org のテストランで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)