### PR TITLE
feat: /healthエンドポイント追加・joinページに友達登録ステップを追加

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "/health", to: proc { [200, {}, ["ok"]] }
+
   post "/webhooks/line", to: "webhooks/line#receive"
 
   namespace :api do

--- a/docs/scrap/2026-05-31_line-friend-registration-flow.md
+++ b/docs/scrap/2026-05-31_line-friend-registration-flow.md
@@ -1,0 +1,95 @@
+# LINE友達登録フローの追加
+
+## 背景・問題
+
+招待リンクから `/join` を開いても、LINEのbot（公式アカウント）を友達追加していないとグループ参加ができない状態だった。
+
+### なぜ友達登録なしでは参加できないか
+
+`auth_controller.rb` の `line` アクションは、LINEのアクセストークンでプロフィールを取得した後、**DBにUserレコードが存在することを前提**としている。
+
+```ruby
+user = User.find_by(line_user_id: profile["userId"])
+unless user
+  render json: { error: "User not found. Please open the LINE bot first." }, status: :not_found
+end
+```
+
+Userレコードはfollowイベント（友達追加）のWebhookで作られる設計になっている。
+
+```ruby
+def handle_follow(event)
+  User.find_or_create_by(line_user_id: line_user_id) do |u|
+    u.display_name = profile["displayName"]
+    ...
+  end
+end
+```
+
+つまり「友達追加 → followイベント → Userレコード作成 → 認証可能」という順序が前提で、この順序を飛ばして参加ボタンを押すとバックエンドで404になっていた。
+
+## 実装
+
+### liff.getFriendship()
+
+LIFFにはbotとの友達関係を取得するAPIがある。
+
+```typescript
+const { friendFlag } = await liff.getFriendship()
+// friendFlag: true → 友達 / false → 未登録
+```
+
+これを `useLiff` フックの初期化時に並列実行し、`isFriend` として返す。
+
+```typescript
+const [p, friendship] = await Promise.all([
+  liff.getProfile(),
+  liff.getFriendship().catch(() => ({ friendFlag: true })), // 取得失敗時はブロックしない
+])
+```
+
+失敗時に `true` にフォールバックしているのは、チャンネル設定の問題などで取得できない場合にユーザーを不当にブロックしないため。
+
+### 友達追加ステップ
+
+`isFriend === false` のとき `JoinPage` はグループ参加UIではなく `AddFriendStep` を表示する。
+
+```tsx
+{isFriend === false ? (
+  <AddFriendStep onRecheckFriendship={recheckFriendship} />
+) : (
+  <JoinContent accessToken={accessToken} />
+)}
+```
+
+`AddFriendStep` の2ステップ：
+
+1. **「友達追加する」ボタン** → `liff.openWindow()` でLINEアプリ内の友達追加画面を開く
+2. **「追加しました →」ボタン** → `recheckFriendship()` を呼んで再確認。`isFriend` が `true` になれば自動的にグループ参加UIに遷移
+
+```typescript
+liff.openWindow({ url: "https://line.me/R/ti/p/@152uuqjs", external: false })
+```
+
+`external: false` はLINEアプリ内ブラウザで開く指定。友達追加後に戻ってきたとき、LIFFページはそのまま維持されている。
+
+## 設計上の判断
+
+### なぜ「参加ボタンを押してからエラーを出す」のではなく「事前チェック」か
+
+- エラーをバックエンドに到達させてから表示するよりも、フロントで事前チェックした方がユーザー体験がよい
+- 「なぜ参加できないのか」を明確なUIで伝えられる（エラーメッセージより友達追加ボタンの方がわかりやすい）
+
+### なぜUserレコードの作成をjoinフローに移さないか
+
+- Userレコードの作成タイミングをfollowイベントに統一しておくことで、「友達追加 = アカウント作成」の責任の境界がはっきりする
+- followイベントのWebhookではプロフィール情報（displayName, pictureUrl）もbotのServer-side APIで取得している。joinフローのアクセストークン経由でも同じ情報は取れるが、フローを混在させると複雑になる
+- 結局、joinには友達登録が必要という業務ルールは変わらないので、フロントで先に誘導する方が自然
+
+## 言語化チェックリスト
+
+- [ ] なぜfollowイベントまでUserレコードが作られないのか説明できるか
+- [ ] `liff.getFriendship()` がどのタイミングで呼ばれているか説明できるか
+- [ ] フォールバック（`.catch(() => ({ friendFlag: true }))`）の理由を説明できるか
+- [ ] `recheckFriendship` 関数の役割と、なぜ状態更新だけで画面遷移できるかを説明できるか
+- [ ] `liff.openWindow({ external: false })` の `external: false` の意味を説明できるか

--- a/frontend/app/join/join-client.tsx
+++ b/frontend/app/join/join-client.tsx
@@ -2,11 +2,14 @@
 
 import { useState, useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
+import liff from "@line/liff"
 import { useLiff } from "@/hooks/use-liff"
 import { toast, Toaster } from "sonner"
 import { ShibaFace } from "@/components/shiba-icons"
 import { Button } from "@/components/ui/button"
 import { api } from "@/lib/api"
+
+const LINE_ADD_FRIEND_URL = "https://line.me/R/ti/p/@152uuqjs"
 
 interface GroupPreview {
   group_name: string
@@ -110,7 +113,7 @@ function JoinContent({ accessToken }: JoinContentProps) {
 }
 
 export default function JoinPage() {
-  const { isLoading, isInClient, accessToken, error } = useLiff()
+  const { isLoading, isInClient, accessToken, isFriend, error, recheckFriendship } = useLiff()
 
   if (isLoading) {
     return (
@@ -148,9 +151,58 @@ export default function JoinPage() {
           </h1>
         </div>
 
-        <Suspense fallback={<p className="text-center text-muted-foreground text-sm">読み込み中...</p>}>
-          <JoinContent accessToken={accessToken} />
-        </Suspense>
+        {isFriend === false ? (
+          <AddFriendStep onRecheckFriendship={recheckFriendship} />
+        ) : (
+          <Suspense fallback={<p className="text-center text-muted-foreground text-sm">読み込み中...</p>}>
+            <JoinContent accessToken={accessToken} />
+          </Suspense>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface AddFriendStepProps {
+  onRecheckFriendship: () => Promise<void>
+}
+
+function AddFriendStep({ onRecheckFriendship }: AddFriendStepProps) {
+  const [isChecking, setIsChecking] = useState(false)
+
+  const handleAddFriend = () => {
+    liff.openWindow({ url: LINE_ADD_FRIEND_URL, external: false })
+  }
+
+  const handleConfirm = async () => {
+    setIsChecking(true)
+    await onRecheckFriendship()
+    setIsChecking(false)
+  }
+
+  return (
+    <div className="text-center space-y-8">
+      <div className="space-y-2">
+        <h2 className="text-xl font-bold text-foreground">友達追加が必要です</h2>
+        <p className="text-sm text-muted-foreground">
+          まんまるしばを使うには、まずLINE公式アカウントを友達追加してください。
+        </p>
+      </div>
+      <div className="space-y-3">
+        <Button
+          onClick={handleAddFriend}
+          className="w-full h-12 bg-gradient-to-r from-primary to-accent text-primary-foreground font-bold rounded-xl shadow-md shadow-primary/20 hover:opacity-90 transition-opacity"
+        >
+          友達追加する
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={handleConfirm}
+          disabled={isChecking}
+          className="w-full h-12 text-muted-foreground hover:text-foreground"
+        >
+          {isChecking ? "確認中..." : "追加しました →"}
+        </Button>
       </div>
     </div>
   )

--- a/frontend/hooks/use-liff.ts
+++ b/frontend/hooks/use-liff.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import liff from "@line/liff"
 
 interface LiffProfile {
@@ -14,7 +14,9 @@ interface UseLiffResult {
   accessToken: string | null
   isLoading: boolean
   isInClient: boolean
+  isFriend: boolean | null
   error: string | null
+  recheckFriendship: () => Promise<void>
 }
 
 export function useLiff(): UseLiffResult {
@@ -22,6 +24,7 @@ export function useLiff(): UseLiffResult {
   const [accessToken, setAccessToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isInClient, setIsInClient] = useState(false)
+  const [isFriend, setIsFriend] = useState<boolean | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -34,19 +37,22 @@ export function useLiff(): UseLiffResult {
 
     liff
       .init({ liffId })
-      .then(() => {
+      .then(async () => {
         const inClient = liff.isInClient()
         setIsInClient(inClient)
-        if (!inClient) return // 外部ブラウザはフォールバック表示のみ
+        if (!inClient) return
         if (!liff.isLoggedIn()) {
           liff.login({ redirectUri: window.location.href })
           return
         }
         setAccessToken(liff.getAccessToken())
-        return liff.getProfile()
-      })
-      .then((p) => {
-        if (p) setProfile(p)
+
+        const [p, friendship] = await Promise.all([
+          liff.getProfile(),
+          liff.getFriendship().catch(() => ({ friendFlag: true })),
+        ])
+        setProfile(p)
+        setIsFriend(friendship.friendFlag)
       })
       .catch((e: Error) => {
         setError(e.message)
@@ -56,5 +62,14 @@ export function useLiff(): UseLiffResult {
       })
   }, [])
 
-  return { profile, accessToken, isLoading, isInClient, error }
+  const recheckFriendship = useCallback(async () => {
+    try {
+      const { friendFlag } = await liff.getFriendship()
+      setIsFriend(friendFlag)
+    } catch {
+      setIsFriend(true)
+    }
+  }, [])
+
+  return { profile, accessToken, isLoading, isInClient, isFriend, error, recheckFriendship }
 }


### PR DESCRIPTION
## 変更内容

### /health エンドポイント追加
- Render.com のヘルスチェック用に `GET /health` を追加
- Rack の inline proc で返すため、コントローラー不要

### joinページに友達登録誘導ステップを追加
- 招待リンクから `/join` を開いても、LINEのbot未友達だとバックエンドで404になる問題を修正
- `liff.getFriendship()` で事前チェックし、未登録なら友達追加UIを表示

**変更後のフロー**
```
招待リンクを開く
  ↓
[未友達] → 友達追加ステップ（「友達追加する」→ LINE友達追加画面）
         → 「追加しました →」→ 再チェック → グループ参加UI
  ↓ [既に友達]
グループ参加UI → 参加する → タイムライン
```

## レビューチェックリスト

- [x] `/health` が正常に 200 を返すか
- [ ] 友達未登録の状態で `/join` を開いたとき、友達追加ステップが表示されるか
- [ ] 「友達追加する」ボタンでLINEの友達追加画面が開くか
- [ ] 「追加しました →」ボタンを押したあと、グループ参加UIに遷移するか
- [ ] 既に友達登録済みの場合、従来通りグループ参加UIが直接表示されるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)